### PR TITLE
gostack-5 - possibilitar pausa remota após troca de podcast track

### DIFF
--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -17,27 +17,28 @@ import {
 
 const Player = ({
   player, play, pause, next, prev, currentSong,
-}) => player.current && (
-  <Container>
-    <CoverBackground source={{ uri: player.podcast.cover }} />
+}) => player.podcast
+  && player.current && (
+    <Container>
+      <CoverBackground source={{ uri: player.podcast.cover }} />
 
-    <SongInfo>
-      <SongTitle>{currentSong.title}</SongTitle>
-      <SongAuthor>{currentSong.artist}</SongAuthor>
-    </SongInfo>
+      <SongInfo>
+        <SongTitle>{currentSong.title}</SongTitle>
+        <SongAuthor>{currentSong.artist}</SongAuthor>
+      </SongInfo>
 
-    <Controls>
-      <ControlButton onPress={prev}>
-        <ControlIcon name="skip-previous" />
-      </ControlButton>
-      <ControlButton onPress={player.playing ? pause : play}>
-        <ControlIcon name={player.playing ? 'pause-circle-filled' : 'play-circle-filled'} />
-      </ControlButton>
-      <ControlButton onPress={next}>
-        <ControlIcon name="skip-next" />
-      </ControlButton>
-    </Controls>
-  </Container>
+      <Controls>
+        <ControlButton onPress={prev}>
+          <ControlIcon name="skip-previous" />
+        </ControlButton>
+        <ControlButton onPress={player.playing ? pause : play}>
+          <ControlIcon name={player.playing ? 'pause-circle-filled' : 'play-circle-filled'} />
+        </ControlButton>
+        <ControlButton onPress={next}>
+          <ControlIcon name="skip-next" />
+        </ControlButton>
+      </Controls>
+    </Container>
 );
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Identificado que após executar um podcast, trocar o episódio e "pausar remotamente", ocorre um erro devido ao TrackPlayer lançar duas vezes o evento "playback-track-changed", isso altera o estado do componente player que por um instante renderiza com campos nulos.
![image](https://user-images.githubusercontent.com/14009814/60480687-dc665c00-9c60-11e9-98f5-d4a7f260e09f.png)

Após realizar a alteração, é possível realizar diversas vezes a ação de pausar sem que seja apresentada a mensagem de erro.

![image](https://user-images.githubusercontent.com/14009814/60480944-dd4bbd80-9c61-11e9-9d7a-93ff17e0e90d.png)
